### PR TITLE
Execution fails for python version 3.11 or above

### DIFF
--- a/pypfop/document_generator.py
+++ b/pypfop/document_generator.py
@@ -2,6 +2,7 @@ import os
 import logging
 import inspect
 import itertools
+from sys import version_info
 
 from pypfop.conversion import xml_to_fo_with_style
 from pypfop.builder import SubprocessBuilder, FopsBuilder
@@ -93,6 +94,20 @@ class DocumentGenerator:
         expected_args = 1
         if inspect.ismethod(template.render):
             expected_args = 2
+        if version_info[0] >= 3 and version_info[1] >= 11: #Python Version >= 3.11
+            if len(inspect.getfullargspec(template.render).args) != expected_args:
+                raise DocumentGeneratorError(
+                    'The template object {} does not implement '
+                    'a 1 argument "render" property (method)'
+                    .format(template)
+                )
+        else:
+            if len(inspect.getargspec(template.render).args) != expected_args:
+                raise DocumentGeneratorError(
+                    'The template object {} does not implement '
+                    'a 1 argument "render" property (method)'
+                    .format(template)
+            return template    
         if len(inspect.getfullargspec(template.render).args) != expected_args:
             raise DocumentGeneratorError(
                 'The template object {} does not implement '

--- a/pypfop/document_generator.py
+++ b/pypfop/document_generator.py
@@ -107,6 +107,7 @@ class DocumentGenerator:
                     'The template object {} does not implement '
                     'a 1 argument "render" property (method)'
                     .format(template)
+                )
             return template    
         if len(inspect.getfullargspec(template.render).args) != expected_args:
             raise DocumentGeneratorError(

--- a/pypfop/document_generator.py
+++ b/pypfop/document_generator.py
@@ -93,7 +93,7 @@ class DocumentGenerator:
         expected_args = 1
         if inspect.ismethod(template.render):
             expected_args = 2
-        if len(inspect.getargspec(template.render).args) != expected_args:
+        if len(inspect.getfullargspec(template.render).args) != expected_args:
             raise DocumentGeneratorError(
                 'The template object {} does not implement '
                 'a 1 argument "render" property (method)'


### PR DESCRIPTION
For python 3.11 or above, 
inspect.getargs is no more supported and causes document_generator to break. 

Ref: https://github.com/grpc/grpc/issues/29962

![image](https://github.com/user-attachments/assets/15f1a407-78f4-4de3-95d4-d31d0ffd8646)
