### PR TITLE
Add feature to directly consume self-generated xslfo content supplied through params.

### DIFF
--- a/pypfop/document_generator.py
+++ b/pypfop/document_generator.py
@@ -161,5 +161,8 @@ class DocumentGenerator:
             out_format = self.out_format
         else:
             out_format = self._check_out_format(out_format)
-        xslfo = self._generate_xslfo(params, copy_params)
+        if "xslfo" not in params:    
+            xslfo = self._generate_xslfo(params, copy_params)
+        else:
+            xslfo = params.xslfo
         return self.builder(xslfo, out_format, self.log)

--- a/pypfop/document_generator.py
+++ b/pypfop/document_generator.py
@@ -164,5 +164,5 @@ class DocumentGenerator:
         if "xslfo" not in params:    
             xslfo = self._generate_xslfo(params, copy_params)
         else:
-            xslfo = params.xslfo
+            xslfo = params["xslfo"]
         return self.builder(xslfo, out_format, self.log)


### PR DESCRIPTION
Directly consume self-generated xslfo content supplied through params. 

Sample code:

```
import pypfop
import pypfop.templates.mako

tfactory = pypfop.templates.mako.Factory()
doc_gen = pypfop.DocumentGenerator(template=tfactory("dummy.mako"))
xslfo = open("test.fo", "rb").read()
fpath = doc_gen.generate(params={"xslfo": xslfo}, out_format="pdf")
```